### PR TITLE
Fix nullpointer exception + remove unused replace

### DIFF
--- a/android/src/main/java/com/odehbros/flutter_file_downloader/core/DownloadTask.java
+++ b/android/src/main/java/com/odehbros/flutter_file_downloader/core/DownloadTask.java
@@ -203,7 +203,7 @@ public class DownloadTask {
 //            extension = realExtension;
 //        }
 
-        return String.format("%s.%s", name, extension.replace(".", ""));
+        return name + (extension == null ? "" : "."+extension);
     }
 
     private String getExtensionFrom(final String name) {


### PR DESCRIPTION
I got a nullpointer when i use the library with REST API, because there was no dot in the URL).
I also remove the replace because, it has no place here, if the code split the string of dot, there are no dot anymore, so no need to replace them.