### PR TITLE
Fixed duplicate calls for onProgress callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.2.2] - TO BE PUBLISHED
+### Fixed
+- Fixed duplicate call for onProgress
+
 ## [1.2.1] - 07-01-2024
 ### Fixed
 - Fixed crash exception when file URL does not contain file extension

--- a/android/src/main/java/com/odehbros/flutter_file_downloader/core/DownloadTask.java
+++ b/android/src/main/java/com/odehbros/flutter_file_downloader/core/DownloadTask.java
@@ -155,10 +155,13 @@ public class DownloadTask {
                 final double progress = (int) ((bytesDownloaded * 100L) / bytesTotal);
                 if (lastProgress != progress) {
                     if (callbacks != null) {
-                        uiThreadHandler.post(() -> {
-                            callbacks.onProgress(progress);
-                            callbacks.onProgress(downloadName, progress);
-                        });
+                        if (downloadName != null && !downloadName.isEmpty()) {
+                            uiThreadHandler.post(() -> {
+                                //removed to avoid redundant calls to onProgress
+//                            callbacks.onProgress(progress);
+                                callbacks.onProgress(downloadName, progress);
+                            });
+                        }
                     }
                     lastProgress = progress;
                 }


### PR DESCRIPTION
Fixed an issue mentioned in #36 where `onProgress` callback is triggered twice each time the progress change