### PR TITLE
Apply deprecation migrations 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
@@ -22,7 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    namespace = "com.odehbros.flutter_file_downloader"
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -6,10 +12,6 @@ if (localPropertiesFile.exists()) {
     }
 }
 
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
@@ -21,11 +23,8 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -35,7 +34,7 @@ android {
     defaultConfig {
         applicationId "com.odehbros.flutter_file_downloader_example"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.4.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+}
+
+include ":app"

--- a/example/lib/multiple_downloads.dart
+++ b/example/lib/multiple_downloads.dart
@@ -54,13 +54,13 @@ class _MultipleDownloadsState extends State<MultipleDownloads> {
         children: [
           Text(
             'Parallel download',
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
           Row(
             children: [
               Expanded(
                 child: Text(isParallel ? 'Enabled' : 'Disabled',
-                    style: Theme.of(context).textTheme.subtitle1),
+                    style: Theme.of(context).textTheme.titleMedium),
               ),
               const SizedBox(width: 16),
               Switch(

--- a/example/lib/settings.dart
+++ b/example/lib/settings.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_file_downloader/flutter_file_downloader.dart';
-import 'package:flutter_file_downloader_example/preferences_manager.dart';
 import 'package:flutter_file_downloader_example/sesstion_settings.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -23,13 +22,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
         children: [
           Text(
             'Enable logs',
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
           Row(
             children: [
               Expanded(
                 child: Text(enabled ? 'Enabled' : 'Disabled',
-                    style: Theme.of(context).textTheme.subtitle1),
+                    style: Theme.of(context).textTheme.titleMedium),
               ),
               const SizedBox(width: 16),
               Switch(
@@ -45,7 +44,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 32),
           Text(
             'Display Notifications',
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
           const SizedBox(height: 8),
           DropdownButtonFormField<NotificationType>(
@@ -74,7 +73,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 32),
           Text(
             'Download destination',
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
           const SizedBox(height: 8),
           DropdownButtonFormField<DownloadDestinations>(
@@ -103,19 +102,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 32),
           Text(
             'Maximum parallel downloads',
-            style: Theme.of(context).textTheme.headline6,
+            style: Theme.of(context).textTheme.titleLarge,
           ),
           Row(
             children: [
               Expanded(
                 child: Text(settings.maximumParallelDownloads.toString(),
-                    style: Theme.of(context).textTheme.subtitle1),
+                    style: Theme.of(context).textTheme.titleMedium),
               ),
               const SizedBox(width: 16),
               IconButton(
                   onPressed: () {
                     setState(() {
-                      settings.setMaximumParallelDownloads(settings.maximumParallelDownloads - 1);
+                      settings.setMaximumParallelDownloads(
+                          settings.maximumParallelDownloads - 1);
                     });
                   },
                   icon: const Icon(Icons.arrow_downward)),
@@ -123,7 +123,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
               IconButton(
                   onPressed: () {
                     setState(() {
-                      settings.setMaximumParallelDownloads(settings.maximumParallelDownloads + 1);
+                      settings.setMaximumParallelDownloads(
+                          settings.maximumParallelDownloads + 1);
                     });
                   },
                   icon: const Icon(Icons.arrow_upward)),


### PR DESCRIPTION
Hi! 
Currently I cannot use this plugin, because the namespace is not defined in the plugins gradle file. 
Here is a part of the Stacktrace, which is printed while compiling: 
```text
[        ] Failed to query the value of property 'buildFlowServiceProperty'.
[        ] > Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated of type BuildFlowService.Parameters
[        ]    > A problem occurred configuring project ':flutter_file_downloader'.
[        ]       > Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
[        ]          > Namespace not specified. Specify a namespace in the module's build file: flutter_file_downloader-2.0.0/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.
[        ]            If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

While fixing the bug, I have done the following:

- apply migration for gradle plugin deprecation: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
- add namespace in order to be compatible with newer gradle plugin version: https://developer.android.com/build/configure-app-module#set-namespace
- apply migration for text styles in sample app: https://docs.flutter.dev/release/breaking-changes/3-19-deprecations

After the applying the migrations it works on my machine (TM)

Thanks for the effort of maintaining this plugin! 
Have a nice day!